### PR TITLE
fix: replace actual API key with a placeholder in .env.today

### DIFF
--- a/.env.today
+++ b/.env.today
@@ -1,0 +1,2 @@
+# Rename this file to .env.local and set your api key
+VUE_APP_FM_KEY= "{REPLACE_WITH_YOUR_ACTUAL_KEY}"


### PR DESCRIPTION
This PR fixes an open security vulnerability by replacing the actual API key in `.env.today` with a placeholder.